### PR TITLE
Broken links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![Bitloops](https://storage.googleapis.com/bitloops-github-assets/bitloops-language-cover-oct22.png)
 
 <p align="center">
-  <a href="https://bitloops.com/docs/bitloops-language/category/quick-start)">Quick Start</a> |
-  <a href="https://bitloops-community.slack.com/)">Slack Community</a> |
-  <a href="https://github.com/bitloops/bitloops-language/discussions)">GitHub Discussions</a> |
+  <a href="https://bitloops.com/docs/bitloops-language/category/quick-start">Quick Start</a> |
+  <a href="https://bitloops-community.slack.com/">Slack Community</a> |
+  <a href="https://github.com/bitloops/bitloops-language/discussions">GitHub Discussions</a> |
   <a href="https://github.com/bitloops/bitloops-language/issues">GitHub Issues</a> |
   <a href="https://github.com/bitloops/bitloops-language/blob/main/CONTRIBUTING.md">Contributing</a>
 </p>


### PR DESCRIPTION
## Proposed changes

The docs had an extra `(` causing broken links. Related issue #27 

## Types of changes

What types of changes does your code introduce to Bitloops Language?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have read the [CONTRIBUTING](https://github.com/bitloops/bitloops-language/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the Bitloops Language CLA (if not, email us: contributor@bitloops.com)
- [ ] I created tests which fail with the change
- [ ] Code complies correctly
- [ ] Unit tests pass locally with my changes
- [ ] All existing tests passed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/extended necessary documentation
- [ ] Any dependent changes have been merged and published in downstream modules

